### PR TITLE
Fix CLIP usage without TensorFlow

### DIFF
--- a/losses/clip_pc.py
+++ b/losses/clip_pc.py
@@ -1,13 +1,23 @@
 # -*- coding: utf-8 -*-
 import os
+import types
+import sys
+import importlib.machinery
 import torch
 import torchvision.transforms.functional as TF
 from PIL import Image
 
-# Avoid importing TensorFlow within transformers as the project does not
-# depend on it and some environments provide a minimal or incompatible
-# TensorFlow stub which leads to AttributeError during runtime.
-os.environ.setdefault("TRANSFORMERS_NO_TF_IMPORT", "1")
+# Prevent transformers from importing TensorFlow. Some environments ship with
+# a minimal or incompatible TensorFlow stub which breaks the runtime when
+# transformers attempts to inspect it.  Setting the environment variable and
+# providing our own lightweight stub avoids any TensorFlow interaction.
+os.environ.setdefault("TRANSFORMERS_NO_TF", "1")
+
+tf_stub = types.ModuleType("tensorflow")
+tf_stub.Tensor = object
+tf_stub.TensorShape = object
+tf_stub.__spec__ = importlib.machinery.ModuleSpec("tensorflow", loader=None)
+sys.modules.setdefault("tensorflow", tf_stub)
 
 from transformers import CLIPProcessor, CLIPModel
 


### PR DESCRIPTION
## Summary
- disable TensorFlow import for CLIP
- add lightweight TensorFlow stub to keep transformers happy

## Testing
- `python -m py_compile losses/clip_pc.py`

------
https://chatgpt.com/codex/tasks/task_e_6868992c03f08333be8dd585bd6d78c5